### PR TITLE
docs: update tracking page view example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ import { MatomoModule, MatomoRouterModule } from 'ngx-matomo-client';
       siteId: 1,
       trackerUrl: 'http://my-matomo-instance',
     }),
-    MatomoRouterModule,
+    MatomoRouterModule.forRoot(),
   ],
 })
 export class AppModule {}


### PR DESCRIPTION
* Site tracking does not work reliably if .forRoot() is not present
  * angular 19
  *  ngx-matomo-client 7 

* Updated example docs to avoid confusion according to github comment of owner in: https://github.com/EmmanuelRoux/ngx-matomo-client/issues/67#issuecomment-1649562783