### PR TITLE
(refactor) move to viewChild signals

### DIFF
--- a/projects/ngx-matomo-client/core/directives/matomo-track-click.directive.spec.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-track-click.directive.spec.ts
@@ -2,7 +2,7 @@ import {
   Component,
   ElementRef,
   provideZoneChangeDetection,
-  ViewChild,
+  viewChild,
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
@@ -22,7 +22,7 @@ import { MatomoTrackClickDirective } from './matomo-track-click.directive';
   imports: [MatomoTrackClickDirective],
 })
 class HostComponent {
-  @ViewChild('button') buttonRef?: ElementRef<HTMLButtonElement>;
+  readonly buttonRef = viewChild.required<ElementRef<HTMLButtonElement>>('button');
 
   category?: string;
   action?: string;
@@ -30,7 +30,7 @@ class HostComponent {
   value?: number;
 
   clickButton(): void {
-    this.buttonRef?.nativeElement.dispatchEvent(new MouseEvent('click'));
+    this.buttonRef().nativeElement.dispatchEvent(new MouseEvent('click'));
   }
 }
 

--- a/projects/ngx-matomo-client/core/directives/matomo-tracker.directive.spec.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-tracker.directive.spec.ts
@@ -3,7 +3,7 @@ import {
   ElementRef,
   provideZoneChangeDetection,
   Type,
-  ViewChild,
+  viewChild,
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
@@ -27,7 +27,7 @@ type HTMLElementEvent = keyof HTMLElementEventMap;
   imports: [MatomoTrackerDirective],
 })
 class HostWithInputEventsComponent {
-  @ViewChild('input') inputRef?: ElementRef<HTMLInputElement>;
+  readonly inputRef = viewChild.required<ElementRef<HTMLInputElement>>('input');
 
   events?: HTMLElementEvent | HTMLElementEvent[] | string | string[];
   defaultCategory?: string;
@@ -36,7 +36,7 @@ class HostWithInputEventsComponent {
   defaultValue?: number;
 
   triggerEvent(event: Event): void {
-    this.inputRef?.nativeElement.dispatchEvent(event);
+    this.inputRef().nativeElement.dispatchEvent(event);
   }
 }
 
@@ -57,7 +57,7 @@ class HostWithInputEventsComponent {
   imports: [MatomoTrackerDirective],
 })
 class HostWithCustomHandler1Component {
-  @ViewChild('input') inputRef?: ElementRef<HTMLInputElement>;
+  readonly inputRef = viewChild.required<ElementRef<HTMLInputElement>>('input');
 
   defaultCategory?: string;
   defaultAction?: string;
@@ -67,7 +67,7 @@ class HostWithCustomHandler1Component {
   arg2?: number;
 
   triggerEvent(event: Event): void {
-    this.inputRef?.nativeElement.dispatchEvent(event);
+    this.inputRef().nativeElement.dispatchEvent(event);
   }
 }
 
@@ -88,7 +88,7 @@ class HostWithCustomHandler1Component {
   imports: [MatomoTrackerDirective],
 })
 class HostWithCustomHandler2Component {
-  @ViewChild('input') inputRef?: ElementRef<HTMLInputElement>;
+  readonly inputRef = viewChild.required<ElementRef<HTMLInputElement>>('input');
 
   defaultCategory?: string;
   defaultAction?: string;
@@ -98,7 +98,7 @@ class HostWithCustomHandler2Component {
   customArgs?: TrackArgs;
 
   triggerEvent(event: Event): void {
-    this.inputRef?.nativeElement.dispatchEvent(event);
+    this.inputRef().nativeElement.dispatchEvent(event);
   }
 }
 

--- a/projects/ngx-matomo-client/form-analytics/directives/track-form-field.directive.spec.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-form-field.directive.spec.ts
@@ -2,7 +2,7 @@ import {
   Component,
   ElementRef,
   provideZoneChangeDetection,
-  ViewChild,
+  viewChild,
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -20,10 +20,9 @@ import { TrackFormDirective } from './track-form.directive';
   imports: [TrackFormDirective, TrackFormFieldDirective],
 })
 class HostComponent {
-  @ViewChild(TrackFormDirective, { read: ElementRef }) containerRef!: ElementRef<HTMLElement>;
-  @ViewChild(TrackFormDirective) formDir!: TrackFormDirective;
-  @ViewChild(TrackFormFieldDirective) fieldDir!: TrackFormFieldDirective;
-  @ViewChild(TrackFormFieldDirective, { read: ElementRef }) fieldElRef!: ElementRef<HTMLElement>;
+  readonly formDir = viewChild.required(TrackFormDirective);
+  readonly fieldDir = viewChild(TrackFormFieldDirective);
+  readonly fieldElRef = viewChild.required(TrackFormFieldDirective, { read: ElementRef });
 
   showField = true;
   ignore: boolean | undefined;
@@ -75,14 +74,14 @@ describe('TrackFormFieldDirective', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(component.fieldElRef.nativeElement.hasAttribute('data-matomo-ignore')).toBeTrue();
+    expect(component.fieldElRef().nativeElement.hasAttribute('data-matomo-ignore')).toBeTrue();
 
     component.ignore = false;
 
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(component.fieldElRef.nativeElement.hasAttribute('data-matomo-ignore')).toBeFalse();
+    expect(component.fieldElRef().nativeElement.hasAttribute('data-matomo-ignore')).toBeFalse();
   });
 
   it('should set data-matomo-name attribute', async () => {
@@ -91,7 +90,7 @@ describe('TrackFormFieldDirective', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(component.fieldElRef.nativeElement.getAttribute('data-matomo-name')).toEqual(
+    expect(component.fieldElRef().nativeElement.getAttribute('data-matomo-name')).toEqual(
       'test-name',
     );
   });
@@ -100,17 +99,17 @@ describe('TrackFormFieldDirective', () => {
     component.fieldName = 'test-name';
     fixture.detectChanges();
     await fixture.whenStable();
-
-    spyOn(component.formDir, 'track');
+    const formDir = component.formDir();
+    spyOn(formDir, 'track');
 
     component.fieldName = 'another-test-name';
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(component.fieldElRef.nativeElement.getAttribute('data-matomo-name')).toEqual(
+    expect(component.fieldElRef().nativeElement.getAttribute('data-matomo-name')).toEqual(
       'another-test-name',
     );
-    expect(component.formDir.track).toHaveBeenCalledTimes(1);
+    expect(formDir.track).toHaveBeenCalledTimes(1);
   });
 
   it('should track form on init', async () => {
@@ -118,8 +117,9 @@ describe('TrackFormFieldDirective', () => {
     component.showField = false;
     fixture.detectChanges();
     await fixture.whenStable();
-    expect(component.fieldDir).toBeUndefined();
-    spyOn(component.formDir, 'track');
+    expect(component.fieldDir()).toBeUndefined();
+    const formDir = component.formDir();
+    spyOn(formDir, 'track');
 
     // When
     component.showField = true;
@@ -127,6 +127,6 @@ describe('TrackFormFieldDirective', () => {
     await fixture.whenStable();
 
     // Then
-    expect(component.formDir.track).toHaveBeenCalledTimes(1);
+    expect(formDir.track).toHaveBeenCalledTimes(1);
   });
 });

--- a/projects/ngx-matomo-client/form-analytics/directives/track-form-submit.directive.spec.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-form-submit.directive.spec.ts
@@ -2,7 +2,7 @@ import {
   Component,
   ElementRef,
   provideZoneChangeDetection,
-  ViewChild,
+  viewChild,
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -24,10 +24,8 @@ import { TrackFormDirective } from './track-form.directive';
   imports: [TrackFormDirective, TrackFormSubmitDirective],
 })
 class HostComponent {
-  @ViewChild(TrackFormDirective, { read: ElementRef }) containerRef!: ElementRef<HTMLElement>;
-  @ViewChild(TrackFormDirective) formDir!: TrackFormDirective;
-  @ViewChild(TrackFormSubmitDirective) submitDir!: TrackFormSubmitDirective;
-  @ViewChild(TrackFormSubmitDirective, { read: ElementRef }) submitElRef!: ElementRef<HTMLElement>;
+  readonly formDir = viewChild.required(TrackFormDirective);
+  readonly submitElRef = viewChild.required(TrackFormSubmitDirective, { read: ElementRef });
 
   ignore: boolean | undefined;
   trackConversion: boolean | undefined;
@@ -78,26 +76,27 @@ describe('TrackFormSubmitDirective', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(component.submitElRef.nativeElement.hasAttribute('data-matomo-ignore')).toBeTrue();
+    expect(component.submitElRef().nativeElement.hasAttribute('data-matomo-ignore')).toBeTrue();
 
     component.ignore = false;
 
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(component.submitElRef.nativeElement.hasAttribute('data-matomo-ignore')).toBeFalse();
+    expect(component.submitElRef().nativeElement.hasAttribute('data-matomo-ignore')).toBeFalse();
   });
 
   it('should track submit', async () => {
-    spyOn(component.formDir, 'trackSubmit');
-    spyOn(component.formDir, 'trackConversion');
+    const formDir = component.formDir();
+    spyOn(formDir, 'trackSubmit');
+    spyOn(formDir, 'trackConversion');
 
-    component.submitElRef.nativeElement.click();
+    component.submitElRef().nativeElement.click();
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(component.formDir.trackSubmit).toHaveBeenCalledTimes(1);
-    expect(component.formDir.trackConversion).not.toHaveBeenCalled();
+    expect(formDir.trackSubmit).toHaveBeenCalledTimes(1);
+    expect(formDir.trackConversion).not.toHaveBeenCalled();
   });
 
   it('should track submit and conversion', async () => {
@@ -105,14 +104,15 @@ describe('TrackFormSubmitDirective', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    spyOn(component.formDir, 'trackSubmit');
-    spyOn(component.formDir, 'trackConversion');
+    const formDir = component.formDir();
+    spyOn(formDir, 'trackSubmit');
+    spyOn(formDir, 'trackConversion');
 
-    component.submitElRef.nativeElement.click();
+    component.submitElRef().nativeElement.click();
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(component.formDir.trackSubmit).toHaveBeenCalledTimes(1);
-    expect(component.formDir.trackConversion).toHaveBeenCalledTimes(1);
+    expect(formDir.trackSubmit).toHaveBeenCalledTimes(1);
+    expect(formDir.trackConversion).toHaveBeenCalledTimes(1);
   });
 });

--- a/projects/ngx-matomo-client/form-analytics/directives/track-form.directive.spec.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-form.directive.spec.ts
@@ -2,7 +2,7 @@ import {
   Component,
   ElementRef,
   provideZoneChangeDetection,
-  ViewChild,
+  viewChild,
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -23,10 +23,9 @@ import { TrackFormDirective } from './track-form.directive';
   imports: [TrackFormDirective],
 })
 class HostComponent {
-  @ViewChild('containerRef', { read: ElementRef }) containerRef!: ElementRef<HTMLElement>;
-  @ViewChild('elRef', { read: ElementRef }) elRef!: ElementRef<HTMLElement>;
-  @ViewChild('submitButton', { read: ElementRef }) submitButtonRef!: ElementRef<HTMLButtonElement>;
-  @ViewChild(TrackFormDirective) dir!: TrackFormDirective;
+  readonly containerRef = viewChild.required('containerRef', { read: ElementRef });
+  readonly submitButtonRef = viewChild.required('submitButton', { read: ElementRef });
+  readonly dir = viewChild.required(TrackFormDirective);
 
   trackConversionOnSubmit: boolean | undefined;
   ignore: boolean | undefined;
@@ -61,7 +60,7 @@ describe('TrackFormDirective', () => {
   });
 
   it('should add data-matomo-form attribute', () => {
-    expect(component.containerRef.nativeElement.hasAttribute('data-matomo-form')).toBeTrue();
+    expect(component.containerRef().nativeElement.hasAttribute('data-matomo-form')).toBeTrue();
   });
 
   it('should add data-matomo-ignore attribute', async () => {
@@ -70,14 +69,14 @@ describe('TrackFormDirective', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(component.containerRef.nativeElement.hasAttribute('data-matomo-ignore')).toBeTrue();
+    expect(component.containerRef().nativeElement.hasAttribute('data-matomo-ignore')).toBeTrue();
 
     component.ignore = false;
 
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(component.containerRef.nativeElement.hasAttribute('data-matomo-ignore')).toBeFalse();
+    expect(component.containerRef().nativeElement.hasAttribute('data-matomo-ignore')).toBeFalse();
   });
 
   it('should set data-matomo-name attribute', async () => {
@@ -86,7 +85,7 @@ describe('TrackFormDirective', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(component.containerRef.nativeElement.getAttribute('data-matomo-name')).toEqual(
+    expect(component.containerRef().nativeElement.getAttribute('data-matomo-name')).toEqual(
       'test-name',
     );
   });
@@ -94,27 +93,27 @@ describe('TrackFormDirective', () => {
   it('should track form on init', async () => {
     await fixture.whenStable();
 
-    expect(formAnalytics.trackForm).toHaveBeenCalledOnceWith(component.containerRef);
+    expect(formAnalytics.trackForm).toHaveBeenCalledOnceWith(component.containerRef());
   });
 
   it('should track form again manually', async () => {
     formAnalytics.trackForm.calls.reset();
 
-    component.dir.track();
+    component.dir().track();
 
-    expect(formAnalytics.trackForm).toHaveBeenCalledOnceWith(component.containerRef);
+    expect(formAnalytics.trackForm).toHaveBeenCalledOnceWith(component.containerRef());
   });
 
   it('should track form submit', async () => {
-    component.dir.trackSubmit();
+    component.dir().trackSubmit();
 
-    expect(formAnalytics.trackFormSubmit).toHaveBeenCalledOnceWith(component.containerRef);
+    expect(formAnalytics.trackFormSubmit).toHaveBeenCalledOnceWith(component.containerRef());
   });
 
   it('should track form conversion', async () => {
-    component.dir.trackConversion();
+    component.dir().trackConversion();
 
-    expect(formAnalytics.trackFormConversion).toHaveBeenCalledOnceWith(component.containerRef);
+    expect(formAnalytics.trackFormConversion).toHaveBeenCalledOnceWith(component.containerRef());
   });
 
   it('should track form conversion automatically', async () => {
@@ -122,8 +121,8 @@ describe('TrackFormDirective', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    component.submitButtonRef.nativeElement.click();
+    component.submitButtonRef().nativeElement.click();
 
-    expect(formAnalytics.trackFormConversion).toHaveBeenCalledOnceWith(component.containerRef);
+    expect(formAnalytics.trackFormConversion).toHaveBeenCalledOnceWith(component.containerRef());
   });
 });

--- a/projects/ngx-matomo-client/form-analytics/directives/track-forms.directive.spec.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-forms.directive.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ElementRef, viewChild, ChangeDetectionStrategy } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatomoFormAnalytics } from '../matomo-form-analytics.service';
 import { TrackFormsDirective } from './track-forms.directive';
@@ -11,9 +11,9 @@ import { TrackFormsDirective } from './track-forms.directive';
   imports: [TrackFormsDirective],
 })
 class HostComponent {
-  @ViewChild('containerRef', { read: ElementRef }) containerRef!: ElementRef<HTMLElement>;
-  @ViewChild('elRef', { read: ElementRef }) elRef!: ElementRef<HTMLElement>;
-  @ViewChild(TrackFormsDirective) dir!: TrackFormsDirective;
+  readonly containerRef = viewChild.required('containerRef', { read: ElementRef });
+  readonly elRef = viewChild.required('elRef', { read: ElementRef });
+  readonly dir = viewChild.required(TrackFormsDirective);
 }
 
 describe('TrackFormsDirective', () => {
@@ -45,18 +45,20 @@ describe('TrackFormsDirective', () => {
   it('should scan for forms on initialization', async () => {
     await fixture.whenStable();
 
-    expect(formAnalytics.scanForForms).toHaveBeenCalledOnceWith(component.containerRef);
+    expect(formAnalytics.scanForForms).toHaveBeenCalledOnceWith(component.containerRef());
   });
 
   it('should track form submit', async () => {
-    component.dir.trackSubmit(component.elRef);
+    const elRef = component.elRef();
+    component.dir().trackSubmit(elRef);
 
-    expect(formAnalytics.trackFormSubmit).toHaveBeenCalledOnceWith(component.elRef);
+    expect(formAnalytics.trackFormSubmit).toHaveBeenCalledOnceWith(elRef);
   });
 
-  it('should track form submit', async () => {
-    component.dir.trackConversion(component.elRef);
+  it('should track form conversion', async () => {
+    const elRef = component.elRef();
+    component.dir().trackConversion(elRef);
 
-    expect(formAnalytics.trackFormConversion).toHaveBeenCalledOnceWith(component.elRef);
+    expect(formAnalytics.trackFormConversion).toHaveBeenCalledOnceWith(elRef);
   });
 });


### PR DESCRIPTION
This pull request refactors the Angular test files to replace usages of the deprecated `@ViewChild` decorator with the new `viewChild` function. This change modernizes the tests and improves type safety and consistency when accessing child components or elements in test host components.