### PR TITLE
(feat): replace deprecated ENVIRONMENT_INITIALIZER

### DIFF
--- a/projects/ngx-matomo-client/core/providers.ts
+++ b/projects/ngx-matomo-client/core/providers.ts
@@ -1,5 +1,5 @@
 import {
-  ENVIRONMENT_INITIALIZER,
+  provideEnvironmentInitializer,
   EnvironmentProviders,
   inject,
   makeEnvironmentProviders,
@@ -41,13 +41,13 @@ export const enum CoreMatomoFeatureKind {
 
 export interface MatomoFeature {
   readonly kind: MatomoFeatureKind;
-  [PRIVATE_MATOMO_PROVIDERS]: Provider[];
+  [PRIVATE_MATOMO_PROVIDERS]: (Provider | EnvironmentProviders)[];
   [PRIVATE_MATOMO_CHECKS]?: (features: MatomoFeatureKind[]) => void;
 }
 
 export function createMatomoFeature(
   kind: MatomoFeatureKind,
-  providers: Provider[],
+  providers: (Provider | EnvironmentProviders)[],
   checks?: (features: MatomoFeatureKind[]) => void,
 ): MatomoFeature {
   return { kind, [PRIVATE_MATOMO_PROVIDERS]: providers, [PRIVATE_MATOMO_CHECKS]: checks };
@@ -90,7 +90,7 @@ export function provideMatomo(
   config: MatomoConfiguration | (() => MatomoConfiguration),
   ...features: MatomoFeature[]
 ): EnvironmentProviders {
-  const providers: Provider[] = [
+  const providers: (Provider | EnvironmentProviders)[] = [
     MatomoTracker,
     ScriptInjector,
     {
@@ -113,13 +113,7 @@ export function provideMatomo(
       provide: ASYNC_INTERNAL_MATOMO_CONFIGURATION,
       useFactory: () => inject(DEFERRED_INTERNAL_MATOMO_CONFIGURATION).configuration,
     },
-    {
-      provide: ENVIRONMENT_INITIALIZER,
-      multi: true,
-      useValue() {
-        inject(MatomoInitializerService).initialize();
-      },
-    },
+    provideEnvironmentInitializer(() => inject(MatomoInitializerService).initialize()),
   ];
   const featuresKind: MatomoFeatureKind[] = [];
 

--- a/projects/ngx-matomo-client/form-analytics/providers.ts
+++ b/projects/ngx-matomo-client/form-analytics/providers.ts
@@ -1,4 +1,4 @@
-import { ENVIRONMENT_INITIALIZER, ErrorHandler, inject } from '@angular/core';
+import { provideEnvironmentInitializer, ErrorHandler, inject } from '@angular/core';
 import {
   MatomoFeature as MatomoFeature,
   ɵcreateMatomoFeature as createMatomoFeature,
@@ -26,19 +26,15 @@ export function withFormAnalytics(config?: MatomoFormAnalyticsConfiguration): Ma
       provide: MATOMO_FORM_ANALYTICS_CONFIGURATION,
       useValue: config,
     },
-    {
-      provide: ENVIRONMENT_INITIALIZER,
-      multi: true,
-      useValue() {
-        const errorHandler = inject(ErrorHandler);
+    provideEnvironmentInitializer(() => {
+      const errorHandler = inject(ErrorHandler);
 
-        // Do NOT wait here for initialization, because app startup should NOT be blocked until deferred config is resolved
-        // However, correctly propagate errors to error handler
-        Promise.resolve(inject(MatomoFormAnalyticsInitializer).initialize()).catch(error =>
-          errorHandler.handleError(error),
-        );
-      },
-    },
+      // Do NOT wait here for initialization, because app startup should NOT be blocked until deferred config is resolved
+      // However, correctly propagate errors to error handler
+      Promise.resolve(inject(MatomoFormAnalyticsInitializer).initialize()).catch(error =>
+        errorHandler.handleError(error),
+      );
+    }),
   ];
 
   return createMatomoFeature(FormAnalyticsMatomoFeatureKind.FormAnalytics, providers);

--- a/projects/ngx-matomo-client/router/providers.ts
+++ b/projects/ngx-matomo-client/router/providers.ts
@@ -1,4 +1,10 @@
-import { ENVIRONMENT_INITIALIZER, inject, Provider, Type } from '@angular/core';
+import {
+  provideEnvironmentInitializer,
+  inject,
+  Provider,
+  Type,
+  EnvironmentProviders,
+} from '@angular/core';
 import {
   MatomoFeature as MatomoFeature,
   MatomoFeatureKind,
@@ -51,7 +57,9 @@ export function withRouter(config?: MatomoRouterConfiguration): MatomoFeature {
   return createMatomoFeature(RouterMatomoFeatureKind.Router, providers);
 }
 
-export function buildInternalRouterProviders(config?: MatomoRouterConfiguration): Provider[] {
+export function buildInternalRouterProviders(
+  config?: MatomoRouterConfiguration,
+): (Provider | EnvironmentProviders)[] {
   return [
     MatomoRouter,
     { provide: MATOMO_ROUTER_ENABLED, useValue: true },
@@ -69,13 +77,7 @@ export function buildInternalRouterProviders(config?: MatomoRouterConfiguration)
       useClass: DefaultPageTitleProvider,
     },
     MatomoRouter,
-    {
-      provide: ENVIRONMENT_INITIALIZER,
-      multi: true,
-      useValue() {
-        inject(MatomoRouter).initialize();
-      },
-    },
+    provideEnvironmentInitializer(() => inject(MatomoRouter).initialize()),
   ];
 }
 


### PR DESCRIPTION
This pull request updates the way environment initializers are provided across the `ngx-matomo-client` project, replacing the older `ENVIRONMENT_INITIALIZER` provider pattern with the newer `provideEnvironmentInitializer` function from Angular. Additionally, it generalizes provider arrays to allow both `Provider` and `EnvironmentProviders` types, improving flexibility and future compatibility.