### PR TITLE
(refactor): remove standalone flag and add host listeners

### DIFF
--- a/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.ts
@@ -47,7 +47,6 @@ function missingServerUrlError(): Error {
   selector: 'matomo-opt-out-form',
   templateUrl: './matomo-opt-out-form.component.html',
   changeDetection: ChangeDetectionStrategy.Eager,
-  standalone: true,
 })
 export class MatomoOptOutFormComponent implements OnInit, OnChanges {
   private readonly sanitizer = inject(DomSanitizer);

--- a/projects/ngx-matomo-client/core/directives/matomo-track-click.directive.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-track-click.directive.ts
@@ -1,10 +1,12 @@
-import { Directive, HostListener, Input, inject } from '@angular/core';
+import { Directive, Input, inject } from '@angular/core';
 import { MatomoTracker } from '../tracker/matomo-tracker.service';
 import { requireNonNull } from '../utils/coercion';
 
 @Directive({
   selector: '[matomoClickCategory][matomoClickAction]',
-  standalone: true,
+  host: {
+    '(click)': 'onClick()',
+  },
 })
 export class MatomoTrackClickDirective {
   private readonly tracker = inject(MatomoTracker);
@@ -14,7 +16,6 @@ export class MatomoTrackClickDirective {
   @Input() matomoClickName?: string;
   @Input() matomoClickValue?: number;
 
-  @HostListener('click')
   onClick(): void {
     this.tracker.trackEvent(
       requireNonNull(this.matomoClickCategory, 'matomo category is required'),

--- a/projects/ngx-matomo-client/core/directives/matomo-tracker.directive.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-tracker.directive.ts
@@ -24,7 +24,6 @@ function coerceEventNames(input: DOMEventInput): EventName[] | null | undefined 
 @Directive({
   selector: '[matomoTracker]',
   exportAs: 'matomo',
-  standalone: true,
 })
 export class MatomoTrackerDirective implements OnDestroy {
   private readonly tracker = inject(MatomoTracker);

--- a/projects/ngx-matomo-client/form-analytics/directives/track-form-field.directive.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-form-field.directive.ts
@@ -11,7 +11,6 @@ import { TrackFormDirective } from './track-form.directive';
 
 @Directive({
   selector: '[matomoTrackFormField]',
-  standalone: true,
   exportAs: 'matomoTrackFormField',
 })
 export class TrackFormFieldDirective implements AfterViewInit {

--- a/projects/ngx-matomo-client/form-analytics/directives/track-form-submit.directive.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-form-submit.directive.ts
@@ -1,17 +1,12 @@
-import {
-  booleanAttribute,
-  Directive,
-  ElementRef,
-  HostListener,
-  inject,
-  Input,
-} from '@angular/core';
+import { booleanAttribute, Directive, ElementRef, inject, Input } from '@angular/core';
 import { throwFormNotFoundError } from './errors';
 import { TrackFormDirective } from './track-form.directive';
 
 @Directive({
   selector: '[matomoTrackFormSubmit]',
-  standalone: true,
+  host: {
+    '(click)': 'trackSubmit()',
+  },
 })
 export class TrackFormSubmitDirective {
   private readonly elementRef: ElementRef<Element> = inject(ElementRef);
@@ -30,7 +25,6 @@ export class TrackFormSubmitDirective {
     }
   }
 
-  @HostListener('click')
   trackSubmit(): void {
     this.form.trackSubmit();
 

--- a/projects/ngx-matomo-client/form-analytics/directives/track-form.directive.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-form.directive.ts
@@ -3,7 +3,6 @@ import {
   booleanAttribute,
   Directive,
   ElementRef,
-  HostListener,
   inject,
   Input,
 } from '@angular/core';
@@ -11,8 +10,10 @@ import { MatomoFormAnalytics } from '../matomo-form-analytics.service';
 
 @Directive({
   selector: '[matomoTrackForm]',
-  standalone: true,
   exportAs: 'matomoTrackForm',
+  host: {
+    '(submit)': 'trackFormConversionOnSubmit()',
+  },
 })
 export class TrackFormDirective implements AfterViewInit {
   private readonly elementRef: ElementRef<Element> = inject(ElementRef);
@@ -63,7 +64,6 @@ export class TrackFormDirective implements AfterViewInit {
     this.tracker.trackFormConversion(this.elementRef);
   }
 
-  @HostListener('submit')
   trackFormConversionOnSubmit(): void {
     if (this.trackConversionOnSubmit) {
       this.trackConversion();

--- a/projects/ngx-matomo-client/form-analytics/directives/track-forms.directive.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-forms.directive.ts
@@ -3,7 +3,6 @@ import { MatomoFormAnalytics } from '../matomo-form-analytics.service';
 
 @Directive({
   selector: '[matomoTrackForms]',
-  standalone: true,
   exportAs: 'matomoTrackForms',
 })
 export class TrackFormsDirective implements AfterViewInit {


### PR DESCRIPTION
This pull request refactors several Angular directives in the Matomo client to improve event binding and compatibility. The main changes are the removal of the `standalone: true` (become the default since v19) property from multiple directives and the replacement of `@HostListener` decorators with explicit event bindings in the directive `host` metadata as recommended here : https://angular.dev/guide/components/host-elements

