### PR TITLE
(feat): Signals input

### DIFF
--- a/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.html
+++ b/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.html
@@ -1,6 +1,6 @@
 <iframe
-  [src]="iframeSrc"
-  [style.border]="border"
-  [style.height]="height"
-  [style.width]="width"
+  [src]="iframeSrc()"
+  [style.border]="border()"
+  [style.height]="height()"
+  [style.width]="width()"
 ></iframe>

--- a/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.spec.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.spec.ts
@@ -223,10 +223,11 @@ describe('MatomoOptOutFormComponent', () => {
     const component = fixture.debugElement.query(By.directive(MatomoOptOutFormComponent))
       ?.componentInstance as MatomoOptOutFormComponent;
 
-    expect(component.serverUrl).toBeFalsy();
+    expect(component.serverUrl()).toBeFalsy();
     expect(() => {
       fixture.detectChanges();
       flush();
+      fixture.detectChanges();
     }).toThrow();
   }));
 
@@ -235,7 +236,7 @@ describe('MatomoOptOutFormComponent', () => {
     const component = fixture.debugElement.query(By.directive(MatomoOptOutFormComponent))
       ?.componentInstance as MatomoOptOutFormComponent;
 
-    expect(component.locale).toEqual('');
+    expect(component.locale()).toEqual('');
     expect(() => fixture.detectChanges()).not.toThrow();
   });
 });

--- a/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.ts
@@ -3,7 +3,8 @@ import {
   input,
   LOCALE_ID,
   computed,
-  signal,
+  resource,
+  linkedSignal,
   SecurityContext,
   inject,
   ChangeDetectionStrategy,
@@ -52,9 +53,15 @@ export class MatomoOptOutFormComponent {
   private readonly config = inject<Promise<InternalMatomoConfiguration>>(
     ASYNC_INTERNAL_MATOMO_CONFIGURATION,
   );
+  private readonly configResource = resource({ loader: () => this.config });
 
-  private readonly defaultServerUrl = signal<string | undefined>(undefined);
-  private readonly configInitialized = signal(false);
+  private readonly defaultServerUrl = linkedSignal(() => {
+    const config = this.configResource.value();
+    if (config && isAutoConfigurationMode(config) && isExplicitTrackerConfiguration(config)) {
+      return getTrackersConfiguration(config)[0].trackerUrl;
+    }
+    return undefined;
+  });
   readonly border = input(DEFAULT_BORDER, { transform: coerceCssSizeBinding });
   readonly width = input(DEFAULT_WIDTH, { transform: coerceCssSizeBinding });
   readonly height = input(DEFAULT_HEIGHT, { transform: coerceCssSizeBinding });
@@ -83,7 +90,7 @@ export class MatomoOptOutFormComponent {
   readonly iframeSrc = computed<SafeResourceUrl>(() => {
     const serverUrlOverride = this.serverUrl();
     const defaultServerUrl = this.defaultServerUrl();
-    const initialized = this.configInitialized();
+    const initialized = this.configResource.hasValue();
 
     let serverUrl: string | null | undefined;
 
@@ -109,15 +116,6 @@ export class MatomoOptOutFormComponent {
 
     return this.sanitizer.bypassSecurityTrustResourceUrl(url);
   });
-
-  constructor() {
-    this.config.then(config => {
-      if (isAutoConfigurationMode(config) && isExplicitTrackerConfiguration(config)) {
-        this.defaultServerUrl.set(getTrackersConfiguration(config)[0].trackerUrl);
-      }
-      this.configInitialized.set(true);
-    });
-  }
 
   static ngAcceptInputType_border: CssSizeInput;
   static ngAcceptInputType_width: CssSizeInput;

--- a/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.ts
@@ -1,11 +1,10 @@
 import {
   Component,
-  Input,
+  input,
   LOCALE_ID,
-  OnChanges,
-  OnInit,
+  computed,
+  signal,
   SecurityContext,
-  SimpleChanges,
   inject,
   ChangeDetectionStrategy,
 } from '@angular/core';
@@ -48,44 +47,29 @@ function missingServerUrlError(): Error {
   templateUrl: './matomo-opt-out-form.component.html',
   changeDetection: ChangeDetectionStrategy.Eager,
 })
-export class MatomoOptOutFormComponent implements OnInit, OnChanges {
+export class MatomoOptOutFormComponent {
   private readonly sanitizer = inject(DomSanitizer);
   private readonly config = inject<Promise<InternalMatomoConfiguration>>(
     ASYNC_INTERNAL_MATOMO_CONFIGURATION,
   );
 
-  private _defaultServerUrl?: string;
-  private _defaultServerUrlInitialized = false;
-  private _border: string = DEFAULT_BORDER;
-  private _width: string = DEFAULT_WIDTH;
-  private _height: string = DEFAULT_HEIGHT;
-  private _iframeSrc: SafeResourceUrl = this.sanitizer.bypassSecurityTrustResourceUrl('');
-  private _serverUrlOverride?: SafeResourceUrl;
-
+  private readonly defaultServerUrl = signal<string | undefined>(undefined);
+  private readonly configInitialized = signal(false);
+  readonly border = input(DEFAULT_BORDER, { transform: coerceCssSizeBinding });
+  readonly width = input(DEFAULT_WIDTH, { transform: coerceCssSizeBinding });
+  readonly height = input(DEFAULT_HEIGHT, { transform: coerceCssSizeBinding });
   /**
    * Set a custom locale for the opt-out form
    * <br>
    * Default is the current app locale available in LOCALE_ID token
    */
-  @Input() locale: string;
+  readonly locale = input<string>(inject(LOCALE_ID, { optional: true }) ?? '');
   /** Font color (note that Matomo currently only supports hexadecimal without leading hash notation) */
-  @Input() color: string = '';
+  readonly color = input<string>('');
   /** Background color (note that Matomo currently only supports hexadecimal without leading hash notation) */
-  @Input() backgroundColor: string = '';
-  @Input() fontSize: string = '';
-  @Input() fontFamily: string = '';
-
-  constructor() {
-    const locale = inject(LOCALE_ID, { optional: true }) ?? '';
-
-    // Set default locale
-    this.locale = locale;
-  }
-
-  get serverUrl(): SafeResourceUrl | undefined {
-    return this._serverUrlOverride;
-  }
-
+  readonly backgroundColor = input<string>('');
+  readonly fontSize = input<string>('');
+  readonly fontFamily = input<string>('');
   /**
    * Set a custom Matomo server url to be used for iframe generation
    * <br>
@@ -94,91 +78,45 @@ export class MatomoOptOutFormComponent implements OnInit, OnChanges {
    * <b>WARNING:</b> This component assumes the url you provide is safe to be used as an iframe
    * `src`. You have to make sure that this url is safe before using this component!
    */
-  @Input()
-  set serverUrl(value: SafeResourceUrl | undefined) {
-    this._serverUrlOverride = value;
-  }
+  readonly serverUrl = input<SafeResourceUrl | undefined>(undefined);
 
-  get iframeSrc(): SafeResourceUrl | undefined {
-    return this._iframeSrc;
-  }
+  readonly iframeSrc = computed<SafeResourceUrl>(() => {
+    const serverUrlOverride = this.serverUrl();
+    const defaultServerUrl = this.defaultServerUrl();
+    const initialized = this.configInitialized();
 
-  get height(): string {
-    return this._height;
-  }
+    let serverUrl: string | null | undefined;
 
-  @Input()
-  set height(value: string) {
-    this._height = coerceCssSizeBinding(value);
-  }
-
-  get width(): string {
-    return this._width;
-  }
-
-  @Input()
-  set width(value: string) {
-    this._width = coerceCssSizeBinding(value);
-  }
-
-  get border(): string {
-    return this._border;
-  }
-
-  @Input()
-  set border(value: string) {
-    this._border = coerceCssSizeBinding(value);
-  }
-
-  ngOnInit() {
-    this.updateUrl();
-
-    this.config.then(config => {
-      if (isAutoConfigurationMode(config) && isExplicitTrackerConfiguration(config)) {
-        this._defaultServerUrl = getTrackersConfiguration(config)[0].trackerUrl;
-      }
-
-      this._defaultServerUrlInitialized = true;
-      this.updateUrl();
-    });
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (
-      'serverUrl' in changes ||
-      'locale' in changes ||
-      'color' in changes ||
-      'backgroundColor' in changes ||
-      'fontSize' in changes ||
-      'fontFamily' in changes
-    ) {
-      this.updateUrl();
-    }
-  }
-
-  private updateUrl(): void {
-    let serverUrl: string | null | undefined = this._defaultServerUrl;
-
-    if (this._serverUrlOverride) {
-      serverUrl = this.sanitizer.sanitize(SecurityContext.RESOURCE_URL, this._serverUrlOverride);
+    if (serverUrlOverride) {
+      serverUrl = this.sanitizer.sanitize(SecurityContext.RESOURCE_URL, serverUrlOverride);
+    } else {
+      serverUrl = defaultServerUrl;
     }
 
     if (!serverUrl) {
-      if (this._defaultServerUrlInitialized) {
+      if (initialized) {
         throw missingServerUrlError();
-      } else {
-        return;
       }
+      return this.sanitizer.bypassSecurityTrustResourceUrl('');
     }
 
     const url = URL_PATTERN.replace('{SERVER}', serverUrl)
-      .replace('{LOCALE}', encodeURIComponent(this.locale))
-      .replace('{COLOR}', encodeURIComponent(this.color))
-      .replace('{BG_COLOR}', encodeURIComponent(this.backgroundColor))
-      .replace('{FONT_SIZE}', encodeURIComponent(this.fontSize))
-      .replace('{FONT_FAMILY}', encodeURIComponent(this.fontFamily));
+      .replace('{LOCALE}', encodeURIComponent(this.locale()))
+      .replace('{COLOR}', encodeURIComponent(this.color()))
+      .replace('{BG_COLOR}', encodeURIComponent(this.backgroundColor()))
+      .replace('{FONT_SIZE}', encodeURIComponent(this.fontSize()))
+      .replace('{FONT_FAMILY}', encodeURIComponent(this.fontFamily()));
 
-    this._iframeSrc = this.sanitizer.bypassSecurityTrustResourceUrl(url);
+    return this.sanitizer.bypassSecurityTrustResourceUrl(url);
+  });
+
+  constructor() {
+    this.config.then(config => {
+      if (isAutoConfigurationMode(config) && isExplicitTrackerConfiguration(config)) {
+        this.defaultServerUrl.set(getTrackersConfiguration(config)[0].trackerUrl);
+      }
+      this.configInitialized.set(true);
+    });
   }
 
   static ngAcceptInputType_border: CssSizeInput;

--- a/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-opt-out-form.component.ts
@@ -85,7 +85,7 @@ export class MatomoOptOutFormComponent {
    * <b>WARNING:</b> This component assumes the url you provide is safe to be used as an iframe
    * `src`. You have to make sure that this url is safe before using this component!
    */
-  readonly serverUrl = input<SafeResourceUrl | undefined>(undefined);
+  readonly serverUrl = input<SafeResourceUrl>();
 
   readonly iframeSrc = computed<SafeResourceUrl>(() => {
     const serverUrlOverride = this.serverUrl();

--- a/projects/ngx-matomo-client/core/directives/matomo-track-click.directive.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-track-click.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, inject } from '@angular/core';
+import { Directive, input, inject } from '@angular/core';
 import { MatomoTracker } from '../tracker/matomo-tracker.service';
 import { requireNonNull } from '../utils/coercion';
 
@@ -11,17 +11,17 @@ import { requireNonNull } from '../utils/coercion';
 export class MatomoTrackClickDirective {
   private readonly tracker = inject(MatomoTracker);
 
-  @Input() matomoClickCategory?: string;
-  @Input() matomoClickAction?: string;
-  @Input() matomoClickName?: string;
-  @Input() matomoClickValue?: number;
+  readonly matomoClickCategory = input<string>();
+  readonly matomoClickAction = input<string>();
+  readonly matomoClickName = input<string>();
+  readonly matomoClickValue = input<number>();
 
   onClick(): void {
     this.tracker.trackEvent(
-      requireNonNull(this.matomoClickCategory, 'matomo category is required'),
-      requireNonNull(this.matomoClickAction, 'matomo action is required'),
-      this.matomoClickName,
-      this.matomoClickValue,
+      requireNonNull(this.matomoClickCategory(), 'matomo category is required'),
+      requireNonNull(this.matomoClickAction(), 'matomo action is required'),
+      this.matomoClickName(),
+      this.matomoClickValue(),
     );
   }
 }

--- a/projects/ngx-matomo-client/core/directives/matomo-tracker.directive.ts
+++ b/projects/ngx-matomo-client/core/directives/matomo-tracker.directive.ts
@@ -1,5 +1,6 @@
-import { Directive, ElementRef, Input, OnDestroy, inject } from '@angular/core';
-import { fromEvent, merge, Subscription } from 'rxjs';
+import { Directive, ElementRef, OnDestroy, inject, input } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { fromEvent, merge, switchMap, EMPTY } from 'rxjs';
 import { MatomoTracker } from '../tracker/matomo-tracker.service';
 import { requireNonNull } from '../utils/coercion';
 
@@ -29,56 +30,47 @@ export class MatomoTrackerDirective implements OnDestroy {
   private readonly tracker = inject(MatomoTracker);
   private readonly elementRef = inject(ElementRef);
 
-  private sub?: Subscription;
-
   /** Set the event category */
-  @Input() matomoCategory?: string;
+  readonly matomoCategory = input<string>();
   /** Set the event action */
-  @Input() matomoAction?: string;
+  readonly matomoAction = input<string>();
   /** Set the event name */
-  @Input() matomoName?: string;
+  readonly matomoName = input<string>();
   /** Set the event value */
-  @Input() matomoValue?: number;
+  readonly matomoValue = input<number>();
 
   /** Track a Matomo event whenever specified DOM event is triggered */
-  @Input()
-  set matomoTracker(input: DOMEventInput) {
-    const eventNames = coerceEventNames(input);
+  readonly matomoTracker = input<DOMEventInput>();
 
-    this.sub?.unsubscribe();
-
-    if (eventNames) {
-      const handlers = eventNames.map(eventName =>
-        fromEvent(this.elementRef.nativeElement, eventName),
-      );
-
-      this.sub = merge(...handlers).subscribe(() => this.trackEvent());
-    } else {
-      this.sub = undefined;
-    }
-  }
+  private sub = toObservable(this.matomoTracker)
+    .pipe(
+      switchMap(input => {
+        const eventNames = coerceEventNames(input);
+        if (!eventNames) return EMPTY;
+        return merge(
+          ...eventNames.map(eventName => fromEvent(this.elementRef.nativeElement, eventName)),
+        );
+      }),
+      takeUntilDestroyed(),
+    )
+    .subscribe(() => this.trackEvent());
 
   ngOnDestroy(): void {
-    this.sub?.unsubscribe();
+    this.sub.unsubscribe();
   }
 
-  /** Track an event using category, action, name and value set as @Input() */
+  /** Track an event using category, action, name and value set as input signals */
   trackEvent(): void;
-
-  /** Track an event using category, action and name set as @Input() and provided value */
-  trackEvent(value: number): void;
-
-  /** Track an event using category and action set as @Input() and provided name and value */
-  trackEvent(name: string, value?: number): void;
-
-  /** Track an event using provided category, action, name and value (any @Input() is used as a default value) */
-  trackEvent(args: TrackArgs): void;
+  /** Track an event using provided name (string), value (number), or both, with input signals as defaults */
+  trackEvent(nameOrValue?: string | number, value?: number): void;
+  /** Track an event using provided args (any input signal is used as a default value) */
+  trackEvent(args?: TrackArgs): void;
 
   trackEvent(arg1?: TrackArgs | string | number, arg2?: number): void {
-    let category = this.matomoCategory;
-    let action = this.matomoAction;
-    let name = this.matomoName;
-    let value = this.matomoValue;
+    let category = this.matomoCategory();
+    let action = this.matomoAction();
+    let name = this.matomoName();
+    let value = this.matomoValue();
 
     if (typeof arg1 === 'object') {
       category = arg1.category ?? category;

--- a/projects/ngx-matomo-client/form-analytics/directives/track-form-field.directive.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-form-field.directive.ts
@@ -1,55 +1,28 @@
-import {
-  AfterViewInit,
-  booleanAttribute,
-  Directive,
-  effect,
-  ElementRef,
-  inject,
-  input,
-} from '@angular/core';
+import { afterRenderEffect, booleanAttribute, Directive, inject, input } from '@angular/core';
 import { throwFormNotFoundError } from './errors';
 import { TrackFormDirective } from './track-form.directive';
 
 @Directive({
   selector: '[matomoTrackFormField]',
   exportAs: 'matomoTrackFormField',
+  host: {
+    '[attr.data-matomo-ignore]': 'matomoIgnore() ? "" : null',
+    '[attr.data-matomo-name]': 'matomoTrackFormField() || null',
+  },
 })
-export class TrackFormFieldDirective implements AfterViewInit {
-  private readonly elementRef: ElementRef<Element> = inject(ElementRef);
+export class TrackFormFieldDirective {
   private readonly form =
     inject(TrackFormDirective, { optional: true }) ??
     throwFormNotFoundError('[matomoTrackFormField]');
 
-  private initialized = false;
   readonly matomoIgnore = input<boolean>(undefined, { transform: booleanAttribute });
   readonly matomoTrackFormField = input<string | null>();
 
   constructor() {
-    effect(() => {
-      const ignore = this.matomoIgnore();
-      if (ignore) {
-        this.elementRef.nativeElement.setAttribute('data-matomo-ignore', '');
-      } else {
-        this.elementRef.nativeElement.removeAttribute('data-matomo-ignore');
-      }
+    afterRenderEffect(() => {
+      this.matomoTrackFormField();
+      this.track();
     });
-    effect(() => {
-      const name = this.matomoTrackFormField();
-      if (name) {
-        this.elementRef.nativeElement.setAttribute('data-matomo-name', name);
-      } else {
-        this.elementRef.nativeElement.removeAttribute('data-matomo-name');
-      }
-
-      if (this.initialized) {
-        this.track();
-      }
-    });
-  }
-
-  ngAfterViewInit(): void {
-    this.track();
-    this.initialized = true;
   }
 
   track(): void {

--- a/projects/ngx-matomo-client/form-analytics/directives/track-form-field.directive.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-form-field.directive.ts
@@ -2,9 +2,10 @@ import {
   AfterViewInit,
   booleanAttribute,
   Directive,
+  effect,
   ElementRef,
   inject,
-  Input,
+  input,
 } from '@angular/core';
 import { throwFormNotFoundError } from './errors';
 import { TrackFormDirective } from './track-form.directive';
@@ -20,25 +21,30 @@ export class TrackFormFieldDirective implements AfterViewInit {
     throwFormNotFoundError('[matomoTrackFormField]');
 
   private initialized = false;
+  readonly matomoIgnore = input<boolean>(undefined, { transform: booleanAttribute });
+  readonly matomoTrackFormField = input<string | null>();
 
-  @Input({ transform: booleanAttribute }) set matomoIgnore(ignore: boolean) {
-    if (ignore) {
-      this.elementRef.nativeElement.setAttribute('data-matomo-ignore', '');
-    } else {
-      this.elementRef.nativeElement.removeAttribute('data-matomo-ignore');
-    }
-  }
+  constructor() {
+    effect(() => {
+      const ignore = this.matomoIgnore();
+      if (ignore) {
+        this.elementRef.nativeElement.setAttribute('data-matomo-ignore', '');
+      } else {
+        this.elementRef.nativeElement.removeAttribute('data-matomo-ignore');
+      }
+    });
+    effect(() => {
+      const name = this.matomoTrackFormField();
+      if (name) {
+        this.elementRef.nativeElement.setAttribute('data-matomo-name', name);
+      } else {
+        this.elementRef.nativeElement.removeAttribute('data-matomo-name');
+      }
 
-  @Input() set matomoTrackFormField(name: string | null | undefined) {
-    if (name) {
-      this.elementRef.nativeElement.setAttribute('data-matomo-name', name);
-    } else {
-      this.elementRef.nativeElement.removeAttribute('data-matomo-name');
-    }
-
-    if (this.initialized) {
-      this.track();
-    }
+      if (this.initialized) {
+        this.track();
+      }
+    });
   }
 
   ngAfterViewInit(): void {

--- a/projects/ngx-matomo-client/form-analytics/directives/track-form-submit.directive.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-form-submit.directive.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Directive, ElementRef, inject, Input } from '@angular/core';
+import { booleanAttribute, Directive, ElementRef, inject, input, effect } from '@angular/core';
 import { throwFormNotFoundError } from './errors';
 import { TrackFormDirective } from './track-form.directive';
 
@@ -15,20 +15,24 @@ export class TrackFormSubmitDirective {
     throwFormNotFoundError('[matomoTrackFormSubmit]');
 
   /** If true, will track a conversion after form submit */
-  @Input({ transform: booleanAttribute }) trackConversion = false;
+  readonly trackConversion = input(false, { transform: booleanAttribute });
+  readonly matomoIgnore = input<boolean>();
 
-  @Input({ transform: booleanAttribute }) set matomoIgnore(ignore: boolean) {
-    if (ignore) {
-      this.elementRef.nativeElement.setAttribute('data-matomo-ignore', '');
-    } else {
-      this.elementRef.nativeElement.removeAttribute('data-matomo-ignore');
-    }
+  constructor() {
+    effect(() => {
+      const ignore = this.matomoIgnore();
+      if (ignore) {
+        this.elementRef.nativeElement.setAttribute('data-matomo-ignore', '');
+      } else {
+        this.elementRef.nativeElement.removeAttribute('data-matomo-ignore');
+      }
+    });
   }
 
   trackSubmit(): void {
     this.form.trackSubmit();
 
-    if (this.trackConversion) {
+    if (this.trackConversion()) {
       this.form.trackConversion();
     }
   }

--- a/projects/ngx-matomo-client/form-analytics/directives/track-form-submit.directive.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-form-submit.directive.ts
@@ -1,15 +1,15 @@
-import { booleanAttribute, Directive, ElementRef, inject, input, effect } from '@angular/core';
+import { booleanAttribute, Directive, inject, input } from '@angular/core';
 import { throwFormNotFoundError } from './errors';
 import { TrackFormDirective } from './track-form.directive';
 
 @Directive({
   selector: '[matomoTrackFormSubmit]',
   host: {
+    '[attr.data-matomo-ignore]': 'matomoIgnore() ? "" : null',
     '(click)': 'trackSubmit()',
   },
 })
 export class TrackFormSubmitDirective {
-  private readonly elementRef: ElementRef<Element> = inject(ElementRef);
   private readonly form =
     inject(TrackFormDirective, { optional: true }) ??
     throwFormNotFoundError('[matomoTrackFormSubmit]');
@@ -17,17 +17,6 @@ export class TrackFormSubmitDirective {
   /** If true, will track a conversion after form submit */
   readonly trackConversion = input(false, { transform: booleanAttribute });
   readonly matomoIgnore = input<boolean>();
-
-  constructor() {
-    effect(() => {
-      const ignore = this.matomoIgnore();
-      if (ignore) {
-        this.elementRef.nativeElement.setAttribute('data-matomo-ignore', '');
-      } else {
-        this.elementRef.nativeElement.removeAttribute('data-matomo-ignore');
-      }
-    });
-  }
 
   trackSubmit(): void {
     this.form.trackSubmit();

--- a/projects/ngx-matomo-client/form-analytics/directives/track-form.directive.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-form.directive.ts
@@ -1,8 +1,7 @@
 import {
-  AfterViewInit,
+  afterRenderEffect,
   booleanAttribute,
   Directive,
-  effect,
   ElementRef,
   inject,
   input,
@@ -13,13 +12,15 @@ import { MatomoFormAnalytics } from '../matomo-form-analytics.service';
   selector: '[matomoTrackForm]',
   exportAs: 'matomoTrackForm',
   host: {
+    'data-matomo-form': '',
+    '[attr.data-matomo-ignore]': 'matomoIgnore() ? "" : null',
+    '[attr.data-matomo-name]': 'matomoTrackForm() || null',
     '(submit)': 'trackFormConversionOnSubmit()',
   },
 })
-export class TrackFormDirective implements AfterViewInit {
+export class TrackFormDirective {
   private readonly elementRef: ElementRef<Element> = inject(ElementRef);
   private readonly tracker = inject(MatomoFormAnalytics);
-  private initialized = false;
 
   /** If true, will track a conversion after form submit */
   readonly trackConversionOnSubmit = input(false, { transform: booleanAttribute });
@@ -27,32 +28,10 @@ export class TrackFormDirective implements AfterViewInit {
   readonly matomoTrackForm = input<string | null>();
 
   constructor() {
-    effect(() => {
-      const ignore = this.matomoIgnore();
-      if (ignore) {
-        this.elementRef.nativeElement.setAttribute('data-matomo-ignore', '');
-      } else {
-        this.elementRef.nativeElement.removeAttribute('data-matomo-ignore');
-      }
+    afterRenderEffect(() => {
+      this.matomoTrackForm();
+      this.track();
     });
-    effect(() => {
-      const name = this.matomoTrackForm();
-      if (name) {
-        this.elementRef.nativeElement.setAttribute('data-matomo-name', name);
-      } else {
-        this.elementRef.nativeElement.removeAttribute('data-matomo-name');
-      }
-
-      if (this.initialized) {
-        this.track();
-      }
-    });
-    this.elementRef.nativeElement.setAttribute('data-matomo-form', '');
-  }
-
-  ngAfterViewInit(): void {
-    this.track();
-    this.initialized = true;
   }
 
   track(): void {

--- a/projects/ngx-matomo-client/form-analytics/directives/track-form.directive.ts
+++ b/projects/ngx-matomo-client/form-analytics/directives/track-form.directive.ts
@@ -2,9 +2,10 @@ import {
   AfterViewInit,
   booleanAttribute,
   Directive,
+  effect,
   ElementRef,
   inject,
-  Input,
+  input,
 } from '@angular/core';
 import { MatomoFormAnalytics } from '../matomo-form-analytics.service';
 
@@ -21,29 +22,31 @@ export class TrackFormDirective implements AfterViewInit {
   private initialized = false;
 
   /** If true, will track a conversion after form submit */
-  @Input({ transform: booleanAttribute }) trackConversionOnSubmit = false;
-
-  @Input({ transform: booleanAttribute }) set matomoIgnore(ignore: boolean) {
-    if (ignore) {
-      this.elementRef.nativeElement.setAttribute('data-matomo-ignore', '');
-    } else {
-      this.elementRef.nativeElement.removeAttribute('data-matomo-ignore');
-    }
-  }
-
-  @Input() set matomoTrackForm(name: string | null | undefined) {
-    if (name) {
-      this.elementRef.nativeElement.setAttribute('data-matomo-name', name);
-    } else {
-      this.elementRef.nativeElement.removeAttribute('data-matomo-name');
-    }
-
-    if (this.initialized) {
-      this.track();
-    }
-  }
+  readonly trackConversionOnSubmit = input(false, { transform: booleanAttribute });
+  readonly matomoIgnore = input<boolean>(undefined, { transform: booleanAttribute });
+  readonly matomoTrackForm = input<string | null>();
 
   constructor() {
+    effect(() => {
+      const ignore = this.matomoIgnore();
+      if (ignore) {
+        this.elementRef.nativeElement.setAttribute('data-matomo-ignore', '');
+      } else {
+        this.elementRef.nativeElement.removeAttribute('data-matomo-ignore');
+      }
+    });
+    effect(() => {
+      const name = this.matomoTrackForm();
+      if (name) {
+        this.elementRef.nativeElement.setAttribute('data-matomo-name', name);
+      } else {
+        this.elementRef.nativeElement.removeAttribute('data-matomo-name');
+      }
+
+      if (this.initialized) {
+        this.track();
+      }
+    });
     this.elementRef.nativeElement.setAttribute('data-matomo-form', '');
   }
 
@@ -65,7 +68,7 @@ export class TrackFormDirective implements AfterViewInit {
   }
 
   trackFormConversionOnSubmit(): void {
-    if (this.trackConversionOnSubmit) {
+    if (this.trackConversionOnSubmit()) {
       this.trackConversion();
     }
   }


### PR DESCRIPTION
This pull request refactors multiple Angular directives in the `ngx-matomo-client` project to use Angular's new `input()` signal-based API instead of the traditional `@Input()` decorator. It also introduces the use of `effect()` for reactive attribute updates and simplifies component logic by leveraging computed properties and signals. These changes modernize the codebase, improve reactivity, and reduce boilerplate, aligning with Angular's latest best practices.