### PR TITLE
(feat): replace Injectable with Service for improved dependency injection

### DIFF
--- a/projects/ngx-matomo-client/core/testing/testing-tracker.ts
+++ b/projects/ngx-matomo-client/core/testing/testing-tracker.ts
@@ -1,4 +1,4 @@
-import { ApplicationInitStatus, inject, Injectable, Provider } from '@angular/core';
+import { ApplicationInitStatus, inject, Service, Provider } from '@angular/core';
 import {
   InternalMatomoTracker,
   InternalMatomoTrackerType,
@@ -15,7 +15,7 @@ export function provideTestingTracker(): Provider[] {
   ];
 }
 
-@Injectable()
+@Service({ autoProvided: false })
 export class MatomoTestingTracker<
   MATOMO = unknown,
   PREFIX extends string = '',

--- a/projects/ngx-matomo-client/core/tracker/internal-matomo-tracker.service.ts
+++ b/projects/ngx-matomo-client/core/tracker/internal-matomo-tracker.service.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
+import { inject, Service, NgZone, PLATFORM_ID } from '@angular/core';
 import { initializeMatomoHolder, MatomoHolder } from '../holder';
 import { Getters, NonEmptyArray, PrefixedType } from '../utils/types';
 import { INTERNAL_MATOMO_CONFIGURATION } from './configuration';
@@ -30,7 +30,7 @@ export function createInternalMatomoTracker(): InternalMatomoTrackerType {
   return disabled || !isBrowser ? new NoopMatomoTracker() : new InternalMatomoTracker();
 }
 
-@Injectable()
+@Service({ autoProvided: false })
 export class InternalMatomoTracker<MATOMO, PREFIX extends string = ''> {
   private readonly ngZone = inject(NgZone);
   private readonly config = inject(INTERNAL_MATOMO_CONFIGURATION);
@@ -67,7 +67,7 @@ export class InternalMatomoTracker<MATOMO, PREFIX extends string = ''> {
   }
 }
 
-@Injectable()
+@Service({ autoProvided: false })
 export class NoopMatomoTracker<
   MATOMO = unknown,
   PREFIX extends string = '',

--- a/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.ts
+++ b/projects/ngx-matomo-client/core/tracker/matomo-initializer.service.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { inject, Service, PLATFORM_ID } from '@angular/core';
 import { initializeMatomoHolder } from '../holder';
 import { runOnce } from '../utils/function';
 import { ScriptInjector } from '../utils/script-injector';
@@ -54,7 +54,7 @@ export class NoopMatomoInitializer implements PublicInterface<MatomoInitializerS
   }
 }
 
-@Injectable()
+@Service({ autoProvided: false })
 export class MatomoInitializerService {
   private readonly config = inject(INTERNAL_MATOMO_CONFIGURATION);
   private readonly deferredConfig = inject(DEFERRED_INTERNAL_MATOMO_CONFIGURATION);

--- a/projects/ngx-matomo-client/core/tracker/matomo-tracker.service.ts
+++ b/projects/ngx-matomo-client/core/tracker/matomo-tracker.service.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, inject, Injectable } from '@angular/core';
+import { DestroyRef, inject, Service } from '@angular/core';
 import { Subject } from 'rxjs';
 import { NonEmptyReadonlyArray, RequireAtLeastOne } from '../utils/types';
 import { InternalMatomoTracker } from './internal-matomo-tracker.service';
@@ -104,7 +104,7 @@ export interface MatomoInstance {
   getIgnoreCampaignsForReferrers(): string[];
 }
 
-@Injectable()
+@Service({ autoProvided: false })
 export class MatomoTracker {
   private readonly delegate: InternalMatomoTracker<MatomoInstance> = inject(
     InternalMatomoTracker<MatomoInstance>,

--- a/projects/ngx-matomo-client/core/utils/script-injector.ts
+++ b/projects/ngx-matomo-client/core/utils/script-injector.ts
@@ -1,8 +1,8 @@
-import { inject, Injectable, INJECTOR, runInInjectionContext, DOCUMENT } from '@angular/core';
+import { inject, Service, INJECTOR, runInInjectionContext, DOCUMENT } from '@angular/core';
 import { MATOMO_SCRIPT_FACTORY } from '../tracker/script-factory';
 import { requireNonNull } from './coercion';
 
-@Injectable()
+@Service({ autoProvided: false })
 export class ScriptInjector {
   private readonly scriptFactory = inject(MATOMO_SCRIPT_FACTORY);
   private readonly injector = inject(INJECTOR);

--- a/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.ts
+++ b/projects/ngx-matomo-client/form-analytics/matomo-form-analytics-initializer.service.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { inject, Injectable, OnDestroy, PLATFORM_ID } from '@angular/core';
+import { inject, Service, OnDestroy, PLATFORM_ID } from '@angular/core';
 import {
   MatomoTracker,
   ɵappendTrailingSlash as appendTrailingSlash,
@@ -16,7 +16,7 @@ import { MatomoFormAnalytics } from './matomo-form-analytics.service';
 
 const DEFAULT_SCRIPT_SUFFIX = 'plugins/FormAnalytics/tracker.min.js';
 
-@Injectable()
+@Service({ autoProvided: false })
 export class MatomoFormAnalyticsInitializer implements OnDestroy {
   private readonly config = inject(INTERNAL_MATOMO_FORM_ANALYTICS_CONFIGURATION);
   private readonly coreConfig = inject(ASYNC_INTERNAL_MATOMO_CONFIGURATION);

--- a/projects/ngx-matomo-client/form-analytics/matomo-form-analytics.service.ts
+++ b/projects/ngx-matomo-client/form-analytics/matomo-form-analytics.service.ts
@@ -1,4 +1,4 @@
-import { ElementRef, inject, Injectable } from '@angular/core';
+import { ElementRef, inject, Service } from '@angular/core';
 import { ɵInternalMatomoTracker as InternalMatomoTracker } from 'ngx-matomo-client/core';
 import { coerceElement } from './utils/coercion';
 
@@ -10,7 +10,7 @@ export interface MatomoFormAnalyticsInstance {
   setTrackingTimer(delayInMilliSeconds: number): void;
 }
 
-@Injectable()
+@Service({ autoProvided: false })
 export class MatomoFormAnalytics {
   private readonly delegate: InternalMatomoTracker<MatomoFormAnalyticsInstance, 'FormAnalytics::'> =
     inject(InternalMatomoTracker<MatomoFormAnalyticsInstance>);

--- a/projects/ngx-matomo-client/router/interceptors/route-data-interceptor.ts
+++ b/projects/ngx-matomo-client/router/interceptors/route-data-interceptor.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable, InjectionToken } from '@angular/core';
+import { inject, Service, InjectionToken } from '@angular/core';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { MatomoECommerceView, MatomoTracker } from 'ngx-matomo-client/core';
 import { Observable } from 'rxjs';
@@ -56,7 +56,7 @@ export interface MatomoRouteData {
  *   },
  * ];
  *
- * @Injectable()
+ * @Service({ autoProvided: false })
  * export class MyCustomInterceptor extends MatomoRouteDataInterceptor {
  *   readonly dataKey = 'myCustomAnalyticsKey';
  * }
@@ -68,7 +68,7 @@ export interface MatomoRouteData {
  * @see MatomoRouteInterceptorBase
  * @see MatomoRouteData
  */
-@Injectable()
+@Service({ autoProvided: false })
 export class MatomoRouteDataInterceptor extends MatomoRouteInterceptorBase<
   MatomoRouteData | undefined
 > {

--- a/projects/ngx-matomo-client/router/matomo-router.service.ts
+++ b/projects/ngx-matomo-client/router/matomo-router.service.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { Injectable, PLATFORM_ID, inject } from '@angular/core';
+import { Service, PLATFORM_ID, inject } from '@angular/core';
 import { Event, NavigationEnd, Router } from '@angular/router';
 import { MatomoTracker, ɵrunOnce as runOnce } from 'ngx-matomo-client/core';
 import {
@@ -76,7 +76,7 @@ function getNavigationEndComparator(config: InternalRouterConfiguration): Naviga
   }
 }
 
-@Injectable()
+@Service({ autoProvided: false })
 export class MatomoRouter {
   private readonly router = inject(Router);
   private readonly platformId = inject(PLATFORM_ID);

--- a/projects/ngx-matomo-client/router/page-title-providers.ts
+++ b/projects/ngx-matomo-client/router/page-title-providers.ts
@@ -1,4 +1,4 @@
-import { Injectable, InjectionToken, inject } from '@angular/core';
+import { Service, InjectionToken, inject } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { NavigationEnd } from '@angular/router';
 import { Observable, of } from 'rxjs';
@@ -21,7 +21,7 @@ export interface PageTitleProvider {
   getCurrentPageTitle(event: NavigationEnd): Observable<string>;
 }
 
-@Injectable()
+@Service({ autoProvided: false })
 export class DefaultPageTitleProvider implements PageTitleProvider {
   private readonly title = inject(Title);
 

--- a/projects/ngx-matomo-client/testing/matomo-testing-tracker.ts
+++ b/projects/ngx-matomo-client/testing/matomo-testing-tracker.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Service } from '@angular/core';
 import { MatomoInstance, MatomoTracker } from 'ngx-matomo-client/core';
 import { MATOMO_TESTING_INSTANCE } from './matomo-testing-instance';
 
@@ -11,7 +11,7 @@ import { MATOMO_TESTING_INSTANCE } from './matomo-testing-instance';
  * All <i>getter</i> methods will immediately resolve to an <i>empty value</i>.
  * This can be customized by setting a custom Matomo instance with {@link setMatomoInstance setMatomoInstance()}.
  */
-@Injectable()
+@Service({ autoProvided: false })
 export class MatomoTestingTracker extends MatomoTracker {
   #fakeInstance: MatomoInstance = inject(MATOMO_TESTING_INSTANCE);
   #paq: unknown[][] = [];


### PR DESCRIPTION
introduced in v22. This pull request refactors the Angular dependency injection annotations throughout the codebase. It replaces the use of the `@Injectable()` decorator with the new `@Service({ autoProvided: false })` decorator from Angular, and updates corresponding imports.